### PR TITLE
Refactor navigation to support SPA localization toggles

### DIFF
--- a/blogs.html
+++ b/blogs.html
@@ -2,25 +2,30 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>My blogs</title>
-    <link rel="stylesheet" href="/css/styles.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sebastian Cubides</title>
+
+    <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
+
+    <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap">
 </head>
 <body>
+    <main id="main-content"></main>
 
-
-    <main id="main-content">
-        <div class="centered-content">
-            <section id="blog">
-                <h1 data-key="blog-title">Blog</h1>
-                <ul id="blog-list"></ul>
-            </section>
-        </div>
-    </main>
-
+    <script>
+        MathJax = {
+            tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']],
+                displayMath: [['$$', '$$'], ['\\[', '\\]']]
+            }
+        };
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script type="module" src="js/main.js"></script>
-
 </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -50,6 +50,11 @@ nav ul li a {
     text-decoration: none;
 }
 
+nav ul li a.active {
+    font-weight: bold;
+    border-bottom: 2px solid var(--link-color);
+}
+
 /* Header styles */
 header {
     border-bottom: 1px solid var(--text-color);

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sebastian Cubides</title>
 
     <!-- Favicon -->
@@ -11,39 +12,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">
     <!-- For iOS devices -->
     <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
-    
+
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap">
 </head>
 <body>
+    <main id="main-content"></main>
 
-    <!-- Main Content -->
-    <main id="main-content">
-        <div class="centered-content">
-            <!-- Your page content here -->
-            <h1>Sebastian Cubides</h1>
-            <h2>A website's whitepaper.</h2>
-
-            <p>
-                This is a website's whitepaper.
-            </p>
-        </div>
-    </main>
-
-    <!-- Scripts -->
-    <!-- Include MathJax for LaTeX rendering -->
     <script>
         MathJax = {
-          tex: {
-            inlineMath: [['$', '$'], ['\\(', '\\)']],
-            displayMath: [['$$', '$$'], ['\\[', '\\]']]
-          }
+            tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']],
+                displayMath: [['$$', '$$'], ['\\[', '\\]']]
+            }
         };
     </script>
-<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-<script type="module" src="js/main.js"></script>
-
-
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/blog.js
+++ b/js/blog.js
@@ -1,11 +1,10 @@
 // blog.js
 
-import { currentLang, getLocalizedUrl } from './translation.js';
-import { loadMarkdown } from './content.js';
+import { currentLang } from './translation.js';
 
 export const blogPosts = [
-    { 
-        id: 'post1', 
+    {
+        id: 'post1',
         title: {
             en: 'A whitepaper on my website',
             es: 'Un whitepaper sobre mi sitio web'
@@ -22,24 +21,33 @@ export const blogPosts = [
     }
 ];
 
-export function loadBlogPosts() {
+export function loadBlogPosts(onSelect) {
     const blogList = document.getElementById('blog-list');
-    if (blogList) {
-        blogList.innerHTML = ''; // Clear existing list
-        blogPosts.forEach(post => {
-            const li = document.createElement('li');
-            const a = document.createElement('a');
-            a.href = '#';
-            a.textContent = post.title[currentLang];
-            a.onclick = (e) => {
-                e.preventDefault();
-                const localizedUrl = getLocalizedUrl(post.url, currentLang);
-                loadMarkdown(localizedUrl);
-            };
-            li.appendChild(a);
-            blogList.appendChild(li);
-        });
-    } else {
+    if (!blogList) {
         console.error('Blog list element not found');
+        return;
     }
+
+    blogList.innerHTML = '';
+    blogPosts.forEach(post => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = `blogs.html?post=${post.id}`;
+        a.textContent = post.title[currentLang];
+        a.addEventListener('click', (event) => {
+            if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                return;
+            }
+            event.preventDefault();
+            if (typeof onSelect === 'function') {
+                onSelect(post);
+            }
+        });
+        li.appendChild(a);
+        blogList.appendChild(li);
+    });
+}
+
+export function getBlogPostById(id) {
+    return blogPosts.find(post => post.id === id);
 }

--- a/js/content.js
+++ b/js/content.js
@@ -1,7 +1,5 @@
 // content.js
 
-import { currentLang, getLocalizedUrl } from './translation.js';
-
 export async function loadMarkdown(url) {
     try {
         const response = await fetch(url);
@@ -10,35 +8,23 @@ export async function loadMarkdown(url) {
         }
         let markdown = await response.text();
 
-        // Process image paths
         markdown = markdown.replace(/!\[([^\]]*)\]\((\/static\/images\/[^\)]+)\)/g, (match, alt, src) => {
             const newSrc = src.replace(/^\/static\//, '');
             return `![${alt}](${newSrc})`;
         });
 
         const html = marked.parse(markdown);
-        
+
         const mainContent = document.getElementById('main-content');
+        if (!mainContent) {
+            return;
+        }
         mainContent.innerHTML = `<div class="centered-content" data-current-url="${url}">${html}</div>`;
 
-        // Process LaTeX after content is loaded
-        MathJax.typesetPromise().then(() => {
-            console.log('MathJax processing complete');
-        }).catch((err) => console.log('MathJax processing failed: ' + err.message));
-
+        if (typeof MathJax !== 'undefined') {
+            MathJax.typesetPromise().catch((err) => console.log('MathJax processing failed: ' + err.message));
+        }
     } catch (error) {
         console.error('Error loading markdown:', error);
-    }
-}
-
-function reloadCurrentContent() {
-    const mainContent = document.getElementById('main-content');
-    const currentContent = mainContent.querySelector('.centered-content');
-    
-    if (currentContent) {
-        const currentUrl = currentContent.getAttribute('data-current-url');
-        if (currentUrl) {
-            loadMarkdown(getLocalizedUrl(currentUrl, currentLang));
-        }
     }
 }

--- a/js/header.js
+++ b/js/header.js
@@ -7,21 +7,21 @@ export function loadHeader() {
             <div class="header-content">
                 <nav>
                     <ul>
-                        <li><a href="index.html" data-translate="home">Home</a></li>
-                        <li><a href="projects.html" data-translate="projects">Projects</a></li>
-                        <li><a href="blogs.html" data-translate="blog">Blog</a></li>
+                        <li><a href="index.html" data-route="index.html" data-i18n="nav.home">Home</a></li>
+                        <li><a href="projects.html" data-route="projects.html" data-i18n="nav.projects">Projects</a></li>
+                        <li><a href="blogs.html" data-route="blogs.html" data-i18n="nav.blog">Blog</a></li>
                     </ul>
                 </nav>
                 <div id="switchers">
                     <div class="toggle-container">
-                        <label class="switch">
+                        <label class="switch" aria-label="Toggle dark mode">
                             <input type="checkbox" id="theme-toggle">
                             <span class="slider round"></span>
                         </label>
                         <span id="theme-label">Dark Mode</span>
                     </div>
                     <div class="toggle-container">
-                        <label class="switch">
+                        <label class="switch" aria-label="Toggle language">
                             <input type="checkbox" id="language-toggle">
                             <span class="slider round"></span>
                         </label>

--- a/js/main.js
+++ b/js/main.js
@@ -1,78 +1,222 @@
 // main.js
 
 import { loadHeader } from './header.js';
-import { loadProjects } from './projects.js';
-import { loadBlogPosts } from './blog.js';
-import { initializeThemeToggle } from './theme.js';
-import { initializeLanguageToggle, currentLang, getLocalizedUrl, translations } from './translation.js';
+import { loadProjects, getProjectById } from './projects.js';
+import { loadBlogPosts, getBlogPostById } from './blog.js';
+import { initializeThemeToggle, refreshThemeLabel } from './theme.js';
+import { initializeLanguageToggle, currentLang, getLocalizedUrl, translatePage, t } from './translation.js';
 import { loadMarkdown } from './content.js';
 
-let currentContentUrl = '';
+const BASE_INDEX = 'index.html';
 
 document.addEventListener('DOMContentLoaded', () => {
     loadHeader();
-    
-    // Initialize toggles
     initializeThemeToggle();
-    initializeLanguageToggle(() => loadContent(window.location.pathname.split('/').pop()));
-    
-    // Load content based on the current page
-    loadContent(window.location.pathname.split('/').pop());
-    
-    // Add event listeners for navigation
-    document.querySelectorAll('nav a').forEach(link => {
-        link.addEventListener('click', (e) => {
-            e.preventDefault();
-            const href = link.getAttribute('href');
-            history.pushState(null, '', href);
-            loadContent(href);
-        });
+    setupNavigation();
+
+    initializeLanguageToggle(() => {
+        renderFromUrl();
+    });
+
+    renderFromUrl();
+
+    window.addEventListener('popstate', () => {
+        renderFromUrl();
     });
 });
 
+function setupNavigation() {
+    document.querySelectorAll('nav a[data-route]').forEach(link => {
+        link.addEventListener('click', (event) => {
+            if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                return;
+            }
+            event.preventDefault();
+            const target = link.getAttribute('href');
+            if (target) {
+                navigateTo(target);
+            }
+        });
+    });
+}
 
-function loadContent(href) {
-    const mainContent = document.getElementById('main-content');
-    mainContent.innerHTML = ''; // Clear existing content
-    mainContent.className = 'centered-content'; // Add the centered-content class
+function navigateTo(path, params = {}) {
+    const query = new URLSearchParams(params).toString();
+    const url = query ? `${path}?${query}` : path;
+    if (window.location.pathname.endsWith(path) && (window.location.search === (query ? `?${query}` : ''))) {
+        renderFromUrl();
+        return;
+    }
+    history.pushState({ path, params }, '', url);
+    renderFromUrl();
+}
 
-    switch (href) {
-        case 'index.html':
-            loadMarkdown(getLocalizedUrl('/content/index.md', currentLang));
-            break;
+function renderFromUrl() {
+    const { path, params } = parseLocation();
+    switch (path) {
         case '':
-            loadMarkdown(getLocalizedUrl('/content/index.md', currentLang));
+        case BASE_INDEX:
+            renderHome();
             break;
         case 'projects.html':
-            createSection('projects', translations[currentLang]['projects-title']);
-            loadProjects();
+            if (params.project) {
+                renderProjectDetail(params.project);
+            } else {
+                renderProjectList();
+            }
             break;
         case 'blogs.html':
-            createSection('blog', translations[currentLang]['blog-title']);
-            loadBlogPosts();
+            if (params.post) {
+                renderBlogDetail(params.post);
+            } else {
+                renderBlogList();
+            }
             break;
         default:
-            // Load markdown content for other pages
-            loadMarkdown(getLocalizedUrl(href, currentLang));
+            renderNotFound();
+            break;
     }
+    updateActiveNav(path);
+    translatePage();
+    refreshThemeLabel();
 }
 
+function renderHome() {
+    document.title = t('page-title.home');
+    loadMarkdown(getLocalizedUrl('content/index.md', currentLang));
+}
 
-function createSection(id, title) {
+function renderProjectList() {
+    document.title = t('page-title.projects');
     const mainContent = document.getElementById('main-content');
+    if (!mainContent) {
+        return;
+    }
+    mainContent.innerHTML = '';
+
+    const container = document.createElement('div');
+    container.classList.add('centered-content');
+
     const section = document.createElement('section');
-    section.id = id;
-    const h1 = document.createElement('h1');
-    h1.setAttribute('data-key', `${id}-title`);
-    h1.textContent = title;
-    const ul = document.createElement('ul');
-    ul.id = `${id}-list`;
-    section.appendChild(h1);
-    section.appendChild(ul);
-    mainContent.appendChild(section);
+    section.id = 'projects';
+
+    const heading = document.createElement('h1');
+    heading.setAttribute('data-i18n', 'headings.projects');
+    heading.textContent = t('headings.projects');
+
+    const list = document.createElement('ul');
+    list.id = 'projects-list';
+
+    section.appendChild(heading);
+    section.appendChild(list);
+    container.appendChild(section);
+    mainContent.appendChild(container);
+
+    loadProjects((project) => {
+        openProject(project);
+    });
 }
 
-// Handle browser back/forward navigation
-window.addEventListener('popstate', () => {
-    loadContent(window.location.pathname.split('/').pop());
-});
+function renderProjectDetail(projectId) {
+    const project = getProjectById(projectId);
+    if (!project) {
+        renderNotFound();
+        return;
+    }
+    document.title = `${project.title[currentLang]} | ${t('page-title.base')}`;
+    loadMarkdown(getLocalizedUrl(project.url, currentLang));
+}
+
+function openProject(project) {
+    navigateTo('projects.html', { project: project.id });
+}
+
+function renderBlogList() {
+    document.title = t('page-title.blog');
+    const mainContent = document.getElementById('main-content');
+    if (!mainContent) {
+        return;
+    }
+    mainContent.innerHTML = '';
+
+    const container = document.createElement('div');
+    container.classList.add('centered-content');
+
+    const section = document.createElement('section');
+    section.id = 'blog';
+
+    const heading = document.createElement('h1');
+    heading.setAttribute('data-i18n', 'headings.blog');
+    heading.textContent = t('headings.blog');
+
+    const list = document.createElement('ul');
+    list.id = 'blog-list';
+
+    section.appendChild(heading);
+    section.appendChild(list);
+    container.appendChild(section);
+    mainContent.appendChild(container);
+
+    loadBlogPosts((post) => {
+        openBlogPost(post);
+    });
+}
+
+function renderBlogDetail(postId) {
+    const post = getBlogPostById(postId);
+    if (!post) {
+        renderNotFound();
+        return;
+    }
+    document.title = `${post.title[currentLang]} | ${t('page-title.base')}`;
+    loadMarkdown(getLocalizedUrl(post.url, currentLang));
+}
+
+function openBlogPost(post) {
+    navigateTo('blogs.html', { post: post.id });
+}
+
+function renderNotFound() {
+    document.title = t('page-title.notFound');
+    const mainContent = document.getElementById('main-content');
+    if (!mainContent) {
+        return;
+    }
+    mainContent.innerHTML = '';
+
+    const container = document.createElement('div');
+    container.classList.add('centered-content');
+
+    const heading = document.createElement('h1');
+    heading.setAttribute('data-i18n', 'headings.notFound');
+    heading.textContent = t('headings.notFound');
+
+    const paragraph = document.createElement('p');
+    paragraph.setAttribute('data-i18n', 'messages.notFound');
+    paragraph.textContent = t('messages.notFound');
+
+    container.appendChild(heading);
+    container.appendChild(paragraph);
+    mainContent.appendChild(container);
+}
+
+function updateActiveNav(path) {
+    const normalized = path || BASE_INDEX;
+    document.querySelectorAll('nav a[data-route]').forEach(link => {
+        const target = link.getAttribute('href');
+        if (!target) {
+            return;
+        }
+        if (target === normalized || (normalized === BASE_INDEX && target === BASE_INDEX)) {
+            link.classList.add('active');
+        } else {
+            link.classList.remove('active');
+        }
+    });
+}
+
+function parseLocation() {
+    const path = window.location.pathname.split('/').pop() || '';
+    const params = Object.fromEntries(new URLSearchParams(window.location.search));
+    return { path, params };
+}

--- a/js/projects.js
+++ b/js/projects.js
@@ -1,45 +1,53 @@
 // projects.js
 
-import { currentLang, getLocalizedUrl } from './translation.js';
-import { loadMarkdown } from './content.js';
+import { currentLang } from './translation.js';
 
 export const projects = [
-    { 
-        id: 'project1', 
+    {
+        id: 'project1',
         title: {
             en: 'Awesome Project',
             es: 'Proyecto Impresionante'
         },
-        url: '/content/projects/project1.md'
+        url: 'content/projects/project1.md'
     },
-    { 
-        id: 'project2', 
+    {
+        id: 'project2',
         title: {
             en: 'Another Project',
             es: 'Otro Proyecto'
         },
-        url: '/content/projects/project2.md'
+        url: 'content/projects/project2.md'
     }
 ];
 
-export function loadProjects() {
+export function loadProjects(onSelect) {
     const projectList = document.getElementById('projects-list');
-    if (projectList) {
-        projectList.innerHTML = ''; // Clear existing list
-        projects.forEach(project => {
-            const li = document.createElement('li');
-            const a = document.createElement('a');
-            a.href = '#';
-            a.textContent = project.title[currentLang];
-            a.onclick = (e) => {
-                e.preventDefault();
-                const localizedUrl = getLocalizedUrl(project.url, currentLang);
-                loadMarkdown(localizedUrl);
-            };
-            li.appendChild(a);
-            projectList.appendChild(li);
-        });
-    } else {
+    if (!projectList) {
         console.error('Project list element not found');
+        return;
     }
+
+    projectList.innerHTML = '';
+    projects.forEach(project => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = `projects.html?project=${project.id}`;
+        a.textContent = project.title[currentLang];
+        a.addEventListener('click', (event) => {
+            if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                return;
+            }
+            event.preventDefault();
+            if (typeof onSelect === 'function') {
+                onSelect(project);
+            }
+        });
+        li.appendChild(a);
+        projectList.appendChild(li);
+    });
+}
+
+export function getProjectById(id) {
+    return projects.find(project => project.id === id);
 }

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,28 +1,37 @@
 // theme.js
 
-import { translations, currentLang } from './translation.js';
+import { getThemeLabel } from './translation.js';
 
 export function initializeThemeToggle() {
     const themeToggle = document.getElementById('theme-toggle');
     const body = document.body;
-    const themeLabel = document.getElementById('theme-label');
-
-    function updateThemeLabel(isDark) {
-        themeLabel.textContent = isDark 
-            ? translations[currentLang]['light-mode'] 
-            : translations[currentLang]['dark-mode'];
+    if (!themeToggle) {
+        return;
     }
 
-    // Check for saved theme in localStorage
     const isDarkMode = localStorage.getItem('theme') === 'dark';
     body.classList.toggle('dark-mode', isDarkMode);
     themeToggle.checked = isDarkMode;
     updateThemeLabel(isDarkMode);
 
     themeToggle.addEventListener('change', () => {
-        body.classList.toggle('dark-mode');
-        const isDark = body.classList.contains('dark-mode');
+        const isDark = themeToggle.checked;
+        body.classList.toggle('dark-mode', isDark);
         localStorage.setItem('theme', isDark ? 'dark' : 'light');
         updateThemeLabel(isDark);
     });
+}
+
+export function refreshThemeLabel() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (themeToggle) {
+        updateThemeLabel(themeToggle.checked);
+    }
+}
+
+function updateThemeLabel(isDark) {
+    const themeLabel = document.getElementById('theme-label');
+    if (themeLabel) {
+        themeLabel.textContent = getThemeLabel(isDark);
+    }
 }

--- a/js/translation.js
+++ b/js/translation.js
@@ -1,125 +1,101 @@
 // translation.js
 
-import { loadMarkdown } from './content.js';
-
 export const translations = {
     en: {
-        'projects': 'Projects',
-        'blog': 'Blog',
-        'projects-title': 'Projects',
-        'blog-title': 'Blog',
-        'home': 'Home',
-        'dark-mode': 'Dark Mode',
-        'light-mode': 'Light Mode',
-        'theme-label': 'Dark Mode',
-        'language-label': 'Español',
-        'about': 'About',
-        'contact': 'Contact'
+        'nav.home': 'Home',
+        'nav.projects': 'Projects',
+        'nav.blog': 'Blog',
+        'headings.projects': 'Projects',
+        'headings.blog': 'Blog',
+        'headings.notFound': 'Content not found',
+        'messages.notFound': 'The content you are looking for could not be found.',
+        'toggle.dark': 'Dark Mode',
+        'toggle.light': 'Light Mode',
+        'toggle.language.label': 'Español',
+        'toggle.language.checkedLabel': 'English',
+        'page-title.base': 'Sebastian Cubides',
+        'page-title.home': 'Sebastian Cubides',
+        'page-title.projects': 'Projects | Sebastian Cubides',
+        'page-title.blog': 'Blog | Sebastian Cubides',
+        'page-title.notFound': 'Not Found | Sebastian Cubides'
     },
     es: {
-        'projects': 'Proyectos',
-        'blog': 'Blog',
-        'projects-title': 'Proyectos',
-        'blog-title': 'Blog',
-        'home': 'Inicio',
-        'dark-mode': 'Modo Oscuro',
-        'light-mode': 'Modo Claro',
-        'theme-label': 'Modo Claro',
-        'language-label': 'English',
-        'about': 'Acerca',
-        'contact': 'Contacto'
+        'nav.home': 'Inicio',
+        'nav.projects': 'Proyectos',
+        'nav.blog': 'Blog',
+        'headings.projects': 'Proyectos',
+        'headings.blog': 'Blog',
+        'headings.notFound': 'Contenido no encontrado',
+        'messages.notFound': 'No pudimos encontrar el contenido que solicitaste.',
+        'toggle.dark': 'Modo oscuro',
+        'toggle.light': 'Modo claro',
+        'toggle.language.label': 'Español',
+        'toggle.language.checkedLabel': 'Inglés',
+        'page-title.base': 'Sebastian Cubides',
+        'page-title.home': 'Sebastian Cubides',
+        'page-title.projects': 'Proyectos | Sebastian Cubides',
+        'page-title.blog': 'Blog | Sebastian Cubides',
+        'page-title.notFound': 'No encontrado | Sebastian Cubides'
     }
 };
 
 export let currentLang = localStorage.getItem('language') || 'en';
 
+export function t(key) {
+    return translations[currentLang][key] || translations.en[key] || key;
+}
+
 export function initializeLanguageToggle(onLanguageChange) {
     const toggle = document.getElementById('language-toggle');
     const label = document.getElementById('language-label');
 
-    // Check for saved language preference in localStorage
-    if (localStorage.getItem('language') === 'es') {
-        currentLang = 'es';
-        toggle.checked = true;
-        label.textContent = 'English';
-    } else {
-        currentLang = 'en';
-        toggle.checked = false;
-        label.textContent = 'Español';
+    if (!toggle || !label) {
+        return;
     }
+
+    toggle.checked = currentLang === 'es';
+    updateLanguageLabel(toggle, label);
+    document.documentElement.setAttribute('lang', currentLang);
 
     toggle.addEventListener('change', () => {
         currentLang = toggle.checked ? 'es' : 'en';
-        label.textContent = toggle.checked ? 'English' : 'Español';
         localStorage.setItem('language', currentLang);
+        document.documentElement.setAttribute('lang', currentLang);
+        updateLanguageLabel(toggle, label);
         if (typeof onLanguageChange === 'function') {
-            onLanguageChange();
+            onLanguageChange(currentLang);
         }
     });
+}
 
-    // Initial translation
-    if (typeof onLanguageChange === 'function') {
-        onLanguageChange();
+export function translatePage() {
+    document.documentElement.setAttribute('lang', currentLang);
+    document.querySelectorAll('[data-i18n]').forEach(element => {
+        const key = element.getAttribute('data-i18n');
+        if (key) {
+            element.textContent = t(key);
+        }
+    });
+    const toggle = document.getElementById('language-toggle');
+    const label = document.getElementById('language-label');
+    if (toggle && label) {
+        updateLanguageLabel(toggle, label);
     }
 }
 
-
-export function translatePage(lang) {
-    document.querySelectorAll('[data-translate]').forEach(element => {
-        const key = element.getAttribute('data-translate');
-        if (translations[lang][key]) {
-            element.textContent = translations[lang][key];
-        }
-    });
-
-    // Translate header elements
-    document.getElementById('theme-label').textContent = translations[lang]['theme-label'];
-    document.getElementById('language-label').textContent = translations[lang]['language-label'];
-    
-    // Translate navigation links
-    document.querySelectorAll('nav a').forEach(link => {
-        const key = link.getAttribute('href').replace('.html', '');
-        if (translations[lang][key]) {
-            link.textContent = translations[lang][key];
-        }
-    });
-
-    // Translate page-specific content
-    const pageSpecificContent = document.querySelector('main h1[data-key]');
-    if (pageSpecificContent) {
-        const key = pageSpecificContent.getAttribute('data-key');
-        if (translations[lang][key]) {
-            pageSpecificContent.textContent = translations[lang][key];
-        }
-    }
-
-    // Update theme toggle label
-    const body = document.body;
-    const isDark = body.classList.contains('dark-mode');
-    const themeLabel = document.getElementById('theme-label');
-    themeLabel.textContent = isDark 
-        ? translations[lang]['light-mode'] 
-        : translations[lang]['dark-mode'];
+export function getThemeLabel(isDark) {
+    return isDark ? t('toggle.light') : t('toggle.dark');
 }
 
 export function getLocalizedUrl(url, lang) {
-    // Remove leading slash if present
     url = url.replace(/^\//, '');
     if (lang === 'es') {
         return url.replace('.md', '_es.md');
-    } else {
-        return url.replace('_es.md', '.md');
     }
+    return url.replace('_es.md', '.md');
 }
 
-function reloadCurrentContent() {
-    const mainContent = document.getElementById('main-content');
-    const currentContent = mainContent.querySelector('.centered-content');
-    
-    if (currentContent) {
-        const currentUrl = currentContent.getAttribute('data-current-url');
-        if (currentUrl) {
-            loadMarkdown(getLocalizedUrl(currentUrl, currentLang));
-        }
-    }
+function updateLanguageLabel(toggle, label) {
+    const key = toggle.checked ? 'toggle.language.checkedLabel' : 'toggle.language.label';
+    label.textContent = t(key);
 }

--- a/projects.html
+++ b/projects.html
@@ -2,19 +2,28 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>My Projects</title>
-    <link rel="stylesheet" href="/css/styles.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sebastian Cubides</title>
+
+    <link rel="icon" type="image/x-icon" href="images/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
+
+    <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap">
 </head>
 <body>
-    <main id="main-content">
-        <div class="centered-content">
-            <section id="projects">
-                <h1 data-key="projects-title">Projects</h1>
-                <ul id="project-list"></ul>
-            </section>
-        </div>
-    </main>
+    <main id="main-content"></main>
+
+    <script>
+        MathJax = {
+            tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']],
+                displayMath: [['$$', '$$'], ['\\[', '\\]']]
+            }
+        };
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script type="module" src="js/main.js"></script>


### PR DESCRIPTION
## Summary
- restructure the static entry pages so they share the SPA shell and MathJax/Markdown tooling
- implement client-side routing for home, blog, and project views with language/theme toggles persisted across navigation
- refresh translation, theme, and content loaders while styling active navigation states

## Testing
- No automated tests were run (not applicable for static site)


------
https://chatgpt.com/codex/tasks/task_e_68ffc9e69ec88333b42d5fa0cb1f4e77